### PR TITLE
[MOSIP-41277] Changing the version from 1.2.0.2 to 1.2.0.3-SNAPSHOT

### DIFF
--- a/commons-packet/commons-packet-manager/pom.xml
+++ b/commons-packet/commons-packet-manager/pom.xml
@@ -9,7 +9,7 @@
     <name>commons-packet-manager</name>
     <description>Mosip commons project </description>
     <url>https://github.com/mosip/commons</url>
-    <version>1.2.0.2</version>
+    <version>1.2.0.3-SNAPSHOT</version>
  <properties>
         <!-- maven -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/commons-packet/commons-packet-service/pom.xml
+++ b/commons-packet/commons-packet-service/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.mosip.commons</groupId>
     <artifactId>commons-packet-service</artifactId>
-    <version>1.2.0.2</version>
+    <version>1.2.0.3-SNAPSHOT</version>
     <name>commons-packet-service</name>
     <description>Mosip commons project </description>
     <url>https://github.com/mosip/commons</url>
@@ -44,7 +44,7 @@
         <khazana.version>1.2.0.1</khazana.version>
         <sonar.coverage.exclusions>**/constant/**,**/config/**,**/httpfilter/**,**/cache/**,**/dto/**,**/entity/**,**/model/**,**/exception/**,**/repository/**,**/security/**,**/*Config.java,**/*BootApplication.java,**/*VertxApplication.java,**/cbeffutil/**,**/*Utils.java,**/*Validator.java,**/*Helper.java,**/verticle/**,**/VidWriter.java/**,**/masterdata/utils/**,**/spi/**,**/core/http/**,"**/LocationServiceImpl.java","**/RegistrationCenterMachineServiceImpl.java","**/RegistrationCenterServiceImpl.java","**/pridgenerator/**","**/idgenerator/prid","**/proxy/**","**/cryptosignature/**"</sonar.coverage.exclusions>
         <sonar.cpd.exclusions>**/dto/**,**/entity/**,**/config/**</sonar.cpd.exclusions>
-        <packet.manager.version>1.2.0.2</packet.manager.version>
+        <packet.manager.version>1.2.0.3-SNAPSHOT</packet.manager.version>
         <springdoc.version>1.5.10</springdoc.version>
  </properties>
 

--- a/commons-packet/pom.xml
+++ b/commons-packet/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.mosip.commons</groupId>
     <artifactId>commons-packet</artifactId>
-    <version>1.2.0.2</version>
+    <version>1.2.0.3-SNAPSHOT</version>
     <name>common-packet</name>
     <description>Common packet manager for MOSIP</description>
     <url>https://github.com/mosip/packet-manager</url>


### PR DESCRIPTION
[[MOSIP-41277] Changing the version from 1.2.0.2 to 1.2.0.3-SNAPSHOT](https://github.com/mosip/packet-manager/commit/e55496dd27f132b3f12d19deb90a96d84c61c46f)

[MOSIP-41277]: https://mosip.atlassian.net/browse/MOSIP-41277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ