### PR TITLE
[MOSIP-42180] - Packet Manager Redis Cache Storing Duplicate BIometrics due to Modalities list changes

### DIFF
--- a/commons-packet/commons-packet-manager/src/main/java/io/mosip/commons/packet/facade/PacketReader.java
+++ b/commons-packet/commons-packet-manager/src/main/java/io/mosip/commons/packet/facade/PacketReader.java
@@ -114,12 +114,13 @@ public class PacketReader {
      * @param process    : the process
      * @return BiometricRecord : the biometric record
      */
+
+    // The caching is removed from this method and moved to the implementation class as part of MOSIP-42180 JIRA. If we use the older implementation class logic (Customized Packet Reader Implementation) then caching logic will not work because of newly introduced getBiometric() method in IPacketReader interface i.e. we need to implement the caching logic in new getBiometric() method in implementation class.
     @PreAuthorize("hasRole('BIOMETRIC_READ')")
-    @Cacheable(value = "packets", key = "'biometrics'.concat('-').#id.concat('-').concat(#person).concat('-').concat(#modalities).concat('-').concat(#source).concat('-').concat(#process)", condition = "#bypassCache == false")
     public BiometricRecord getBiometric(String id, String person, List<String> modalities, String source, String process, boolean bypassCache) {
         LOGGER.info(PacketManagerLogger.SESSIONID, PacketManagerLogger.REGISTRATIONID, id,
                 "getBiometric for source : " + source + " process : " + process);
-        return getProvider(source, process).getBiometric(id, person, modalities, source, process);
+        return getProvider(source, process).getBiometric(id, person, modalities, source, process, bypassCache);
     }
 
     /**

--- a/commons-packet/commons-packet-manager/src/main/java/io/mosip/commons/packet/impl/PacketReaderImpl.java
+++ b/commons-packet/commons-packet-manager/src/main/java/io/mosip/commons/packet/impl/PacketReaderImpl.java
@@ -9,9 +9,7 @@ import static io.mosip.commons.packet.constants.PacketManagerConstants.REFNUMBER
 import static io.mosip.commons.packet.constants.PacketManagerConstants.TYPE;
 import static io.mosip.commons.packet.constants.PacketManagerConstants.VALUE;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -29,32 +27,28 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.util.Lists;
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.mosip.commons.packet.constants.PacketManagerConstants;
 import io.mosip.commons.packet.dto.Document;
 import io.mosip.commons.packet.dto.Packet;
 import io.mosip.commons.packet.dto.PacketInfo;
-import io.mosip.commons.packet.exception.ApiNotAccessibleException;
 import io.mosip.commons.packet.exception.GetAllIdentityException;
 import io.mosip.commons.packet.exception.GetAllMetaInfoException;
 import io.mosip.commons.packet.exception.GetBiometricException;
 import io.mosip.commons.packet.exception.GetDocumentException;
-import io.mosip.commons.packet.exception.PacketDecryptionFailureException;
-import io.mosip.commons.packet.exception.PacketKeeperException;
 import io.mosip.commons.packet.exception.PacketValidationFailureException;
 import io.mosip.commons.packet.keeper.PacketKeeper;
 import io.mosip.commons.packet.spi.IPacketReader;
 import io.mosip.commons.packet.util.IdSchemaUtils;
-import io.mosip.commons.packet.util.PacketManagerHelper;
 import io.mosip.commons.packet.util.PacketManagerLogger;
 import io.mosip.commons.packet.util.PacketValidator;
 import io.mosip.commons.packet.util.ZipUtils;
@@ -91,6 +85,8 @@ public class PacketReaderImpl implements IPacketReader {
 	@Autowired
 	private PacketValidator packetValidator;
 
+	@Autowired
+	private CacheManager cacheManager;
 	/**
 	 * Perform packet validations and audit errors. List of validations - 1. schema
 	 * & idobject reference validation 2. files validation 3. decrypted packet
@@ -231,55 +227,18 @@ public class PacketReaderImpl implements IPacketReader {
 	}
 
 	@Override
-	public BiometricRecord getBiometric(String id, String biometricFieldName, List<String> modalities, String source,
-			String process) {
+	public BiometricRecord getBiometric(String id, String biometricFieldName, List<String> modalities, String source, String process, boolean byPassCache) {
 		LOGGER.info(PacketManagerLogger.SESSIONID, PacketManagerLogger.REGISTRATIONID, id,
-				"getBiometric :: for - " + biometricFieldName);
+				"getBiometric :: for - " + biometricFieldName + " with byPassCache - " + byPassCache);
 		BiometricRecord biometricRecord = null;
-		String packetName = null;
-		String fileName = null;
+
 		try {
-			String bioString = packetReader.getField(id, biometricFieldName, source, process, false);//(String) idobjectMap.get(biometricFieldName);
-			JSONObject biometricMap = null;
-			if (bioString != null)
-				biometricMap = new JSONObject(bioString);
-			if (bioString == null || biometricMap == null || biometricMap.isNull(VALUE)) {
-				// biometric file not present in idobject. Search in meta data.
-				Map<String, String> metadataMap = getMetaInfo(id, source, process);
-				String operationsData = metadataMap.get(META_INFO_OPERATIONS_DATA);
-				if (StringUtils.isNotEmpty(operationsData)) {
-					JSONArray jsonArray = new JSONArray(operationsData);
-					for (int i = 0; i < jsonArray.length(); i++) {
-						JSONObject jsonObject = (JSONObject) jsonArray.get(i);
-						if (jsonObject.has(LABEL)
-								&& jsonObject.get(LABEL).toString().equalsIgnoreCase(biometricFieldName)) {
-							packetName = ID;
-							fileName = jsonObject.isNull(VALUE) ? null : jsonObject.get(VALUE).toString();
-							break;
-						}
-					}
-				}
-			} else {
-				String idSchemaVersion = packetReader.getField(id,
-						idSchemaUtils.getIdschemaVersionFromMappingJson(), source, process, false);
-				Double schemaVersion = idSchemaVersion != null ? Double.valueOf(idSchemaVersion) : null;
-				packetName = idSchemaUtils.getSource(biometricFieldName, schemaVersion);
-				fileName = biometricMap.get(VALUE).toString();
-			}
-
-			if (packetName == null || fileName == null)
-				return null;
-
-			Packet packet = packetKeeper.getPacket(getPacketInfo(id, packetName, source, process));
-			InputStream biometrics = ZipUtils.unzipAndGetFile(packet.getPacket(), fileName);
-			if (biometrics == null)
-				return null;
-			BIR bir = CbeffValidator.getBIRFromXML(IOUtils.toByteArray(biometrics));
+			BIR bir = loadBiometricsFromObjectStore(id, biometricFieldName, source, process, byPassCache);
 			biometricRecord = new BiometricRecord();
 			if(bir.getOthers() != null) {
 				HashMap<String, String> others = new HashMap<>();
 				bir.getOthers().entrySet().forEach(e -> {
-						others.put(e.getKey(), e.getValue());
+					others.put(e.getKey(), e.getValue());
 				});
 				biometricRecord.setOthers(others);
 			}
@@ -298,6 +257,88 @@ public class PacketReaderImpl implements IPacketReader {
 		}
 
 		return biometricRecord;
+	}
+
+	// Kept for backward compatibility. This method will not utilize the cache. Will be removed in future
+	@Override
+	public BiometricRecord getBiometric(String id, String biometricFieldName, List<String> modalities, String source, String process) {
+		return getBiometric(id, biometricFieldName, modalities, source, process, false);
+	}
+
+	private String generateKey(String id, String biometricFieldName, String source, String process) {
+		return String.format("%s-%s-%s-%s", id, biometricFieldName, source, process);
+	}
+
+	private BIR loadBiometricsFromObjectStore(String id, String biometricFieldName, String source, String process, boolean byPassCache) throws Exception {
+		String cacheKey = generateKey(id, biometricFieldName, source, process);
+		Cache cache = cacheManager.getCache("packets");
+
+		if(byPassCache || cache == null) {
+			LOGGER.debug(PacketManagerLogger.SESSIONID, PacketManagerLogger.REGISTRATIONID, id,
+					"Skipping Cache due to byPassCache : " + byPassCache + " or IsCachePresent : " + (cache != null));
+			return loadBiometricsFromObjectStore(id, biometricFieldName, source, process);
+		}
+
+		BIR cachedValue = cache.get(cacheKey, BIR.class);
+		if(cachedValue != null) {
+			LOGGER.debug(PacketManagerLogger.SESSIONID, PacketManagerLogger.REGISTRATIONID, id,
+					"Cache Found for the Key : " + cacheKey);
+			return cachedValue;
+		}
+
+		LOGGER.debug(PacketManagerLogger.SESSIONID, PacketManagerLogger.REGISTRATIONID, id,
+				"Cache not found for the Key : " + cacheKey + " Loading biometrics from ObjectStore");
+		BIR bir = loadBiometricsFromObjectStore(id, biometricFieldName, source, process);
+		if(bir != null) {
+			LOGGER.debug(PacketManagerLogger.SESSIONID, PacketManagerLogger.REGISTRATIONID, id,
+					"Adding cache the Key : " + cacheKey);
+			cache.put(cacheKey, bir);
+		}
+
+		return bir;
+	}
+
+	private BIR loadBiometricsFromObjectStore(String id, String biometricFieldName, String source, String process) throws Exception {
+		String packetName = null;
+		String fileName = null;
+
+		String bioString = packetReader.getField(id, biometricFieldName, source, process, false);//(String) idobjectMap.get(biometricFieldName);
+		JSONObject biometricMap = null;
+		if (bioString != null)
+			biometricMap = new JSONObject(bioString);
+		if (bioString == null || biometricMap == null || biometricMap.isNull(VALUE)) {
+			// biometric file not present in idobject. Search in meta data.
+			Map<String, String> metadataMap = getMetaInfo(id, source, process);
+			String operationsData = metadataMap.get(META_INFO_OPERATIONS_DATA);
+			if (StringUtils.isNotEmpty(operationsData)) {
+				JSONArray jsonArray = new JSONArray(operationsData);
+				for (int i = 0; i < jsonArray.length(); i++) {
+					JSONObject jsonObject = (JSONObject) jsonArray.get(i);
+					if (jsonObject.has(LABEL)
+							&& jsonObject.get(LABEL).toString().equalsIgnoreCase(biometricFieldName)) {
+						packetName = ID;
+						fileName = jsonObject.isNull(VALUE) ? null : jsonObject.get(VALUE).toString();
+						break;
+					}
+				}
+			}
+		} else {
+			String idSchemaVersion = packetReader.getField(id,
+					idSchemaUtils.getIdschemaVersionFromMappingJson(), source, process, false);
+			Double schemaVersion = idSchemaVersion != null ? Double.valueOf(idSchemaVersion) : null;
+			packetName = idSchemaUtils.getSource(biometricFieldName, schemaVersion);
+			fileName = biometricMap.get(VALUE).toString();
+		}
+
+		if (packetName == null || fileName == null)
+			return null;
+
+		Packet packet = packetKeeper.getPacket(getPacketInfo(id, packetName, source, process));
+		InputStream biometrics = ZipUtils.unzipAndGetFile(packet.getPacket(), fileName);
+		if (biometrics == null)
+			return null;
+
+		return CbeffValidator.getBIRFromXML(IOUtils.toByteArray(biometrics));
 	}
 
 	@Override

--- a/commons-packet/commons-packet-manager/src/main/java/io/mosip/commons/packet/spi/IPacketReader.java
+++ b/commons-packet/commons-packet-manager/src/main/java/io/mosip/commons/packet/spi/IPacketReader.java
@@ -29,4 +29,8 @@ public interface IPacketReader {
     public Map<String, String> getMetaInfo(String id, String source, String process);
 
     public List<Map<String, String>> getAuditInfo(String id, String source, String process);
+
+    public default BiometricRecord getBiometric(String id, String biometricSchemaField, List<String> modalities, String source, String process, boolean byPassCache) {
+        return null;
+    };
 }

--- a/commons-packet/commons-packet-manager/src/test/java/io/mosip/commons/packet/test/facade/PacketReaderTest.java
+++ b/commons-packet/commons-packet-manager/src/test/java/io/mosip/commons/packet/test/facade/PacketReaderTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,6 +25,8 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.commons.khazana.dto.ObjectDto;
@@ -45,6 +48,9 @@ import io.mosip.kernel.biometrics.entities.RegistryIDType;
 @PrepareForTest({PacketHelper.class})
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class PacketReaderTest {
+
+    @Mock
+    private CacheManager cacheManager;
 
     @InjectMocks
     private PacketReader packetReader = new PacketReader();
@@ -74,7 +80,8 @@ public class PacketReaderTest {
         allFields.put("phone", "1234567");
 
         Mockito.when(packetReaderProvider.getAll(anyString(), anyString(), anyString())).thenReturn(allFields);
-
+        Cache mockCache = Mockito.mock(Cache.class);
+        Mockito.when(cacheManager.getCache("packets")).thenReturn(mockCache);
     }
 
     @Test
@@ -156,7 +163,7 @@ public class PacketReaderTest {
         BiometricRecord biometricRecord = new BiometricRecord();
         biometricRecord.setSegments(birTypeList);
 
-        Mockito.when(packetReaderProvider.getBiometric(anyString(), anyString(), anyList(), anyString(), anyString())).thenReturn(biometricRecord);
+        Mockito.when(packetReaderProvider.getBiometric(anyString(), anyString(), anyList(), anyString(), anyString(), anyBoolean())).thenReturn(biometricRecord);
 
         BiometricRecord result = packetReader.getBiometric(id, "individualBiometrics", Lists.newArrayList(), source, process, true);
 

--- a/commons-packet/commons-packet-manager/src/test/java/io/mosip/commons/packet/test/impl/PacketReaderImplTest.java
+++ b/commons-packet/commons-packet-manager/src/test/java/io/mosip/commons/packet/test/impl/PacketReaderImplTest.java
@@ -28,11 +28,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -69,6 +72,9 @@ import io.mosip.kernel.core.util.exception.JsonProcessingException;
 @PropertySource("classpath:application-test.properties")
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class PacketReaderImplTest {
+
+    @Mock
+    private CacheManager cacheManager;
 
     @InjectMocks
     private IPacketReader iPacketReader = new PacketReaderImpl();
@@ -216,6 +222,8 @@ public class PacketReaderImplTest {
         when(idSchemaUtils.getSource(any(), any())).thenReturn("id");
         when(idSchemaUtils.getIdschemaVersionFromMappingJson()).thenReturn("0.1");
 
+        Cache mockCache = Mockito.mock(Cache.class);
+        Mockito.when(cacheManager.getCache("packets")).thenReturn(mockCache);
     }
 
     @Test
@@ -328,7 +336,7 @@ public class PacketReaderImplTest {
 
         when(packetReader.getField("id",biometricFieldName,"source","process",false)).thenReturn(keyValueMap.get(biometricFieldName).toString());
 
-        BiometricRecord result = iPacketReader.getBiometric("id", biometricFieldName, null, "source", "process");
+        BiometricRecord result = iPacketReader.getBiometric("id", biometricFieldName, null, "source", "process", false);
 
         assertTrue("Should be true", result.getSegments().size() == 2);
     }
@@ -371,7 +379,7 @@ public class PacketReaderImplTest {
         PowerMockito.mockStatic(CbeffValidator.class);
         when(CbeffValidator.getBIRFromXML(any())).thenReturn(birType);
 
-        BiometricRecord result = iPacketReader.getBiometric("id", "officerBiometric", null, "source", "process");
+        BiometricRecord result = iPacketReader.getBiometric("id", "officerBiometric", null, "source", "process", false);
 
         assertTrue("Should be true", result.getSegments().size() == 2);
     }


### PR DESCRIPTION
[MOSIP-42180] - Packet Manager Redis Cache Storing Duplicate BIometrics due to Modalities list changes

[MOSIP-42180]: https://mosip.atlassian.net/browse/MOSIP-42180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ