### PR TITLE
#2384: Update POM, helm chart and install script versions for 1.3.1 release

### DIFF
--- a/commons-packet/commons-packet-manager/pom.xml
+++ b/commons-packet/commons-packet-manager/pom.xml
@@ -9,7 +9,7 @@
     <name>commons-packet-manager</name>
     <description>Mosip commons project </description>
     <url>https://github.com/mosip/commons</url>
-    <version>1.3.1-rc.1</version>
+    <version>1.3.1-SNAPSHOT</version>
  <properties>
         <!-- maven -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -28,16 +28,16 @@
         <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
         <hazelcast.kubernetes.version>1.3.1</hazelcast.kubernetes.version>
 
-        <kernel-keymanager-service.version>1.4.1-rc.1</kernel-keymanager-service.version>
-        <kernel-idobjectvalidator.version>1.3.1-rc.1</kernel-idobjectvalidator.version>
-        <kernel.core.version>1.3.1-rc.1</kernel.core.version>
+        <kernel-keymanager-service.version>1.4.1-SNAPSHOT</kernel-keymanager-service.version>
+        <kernel-idobjectvalidator.version>1.3.1-SNAPSHOT</kernel-idobjectvalidator.version>
+        <kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
         <kernel.biometrics.api.version>1.3.0</kernel.biometrics.api.version>
         <kernel.cbeffutil.api.version>1.3.0</kernel.cbeffutil.api.version>
         <kernel.auth.adaptor.version>1.3.0</kernel.auth.adaptor.version>
-        <kernel-dataaccess-hibernate.version>1.3.1-rc.1</kernel-dataaccess-hibernate.version>
-        <kernel.logger.logback.version>1.3.1-rc.1</kernel.logger.logback.version>
-        <khazana.version>1.3.2-rc.1</khazana.version>
-         <kernel.bom.version>1.3.1-rc.1</kernel.bom.version>
+        <kernel-dataaccess-hibernate.version>1.3.1-SNAPSHOT</kernel-dataaccess-hibernate.version>
+        <kernel.logger.logback.version>1.3.1-SNAPSHOT</kernel.logger.logback.version>
+        <khazana.version>1.3.2-SNAPSHOT</khazana.version>
+         <kernel.bom.version>1.3.1-SNAPSHOT</kernel.bom.version>
 
          <mockito.core.version>3.11.2</mockito.core.version>
         <sonar.coverage.exclusions>**/constants/**,**/config/**,**/audit/**,**/util/**,**/dto/**,**/entity/**,**/model/**,**/exception/**,**/repository/**,**/security/**,**/*Config.java,**/*BootApplication.java,**/*VertxApplication.java,**/cbeffutil/**,**/*Utils.java,**/*Validator.java,**/*Helper.java,**/verticle/**,**/VidWriter.java/**,**/masterdata/utils/**,**/spi/**,**/core/http/**,"**/LocationServiceImpl.java","**/RegistrationCenterMachineServiceImpl.java","**/RegistrationCenterServiceImpl.java","**/pridgenerator/**","**/idgenerator/prid","**/proxy/**","**/cryptosignature/**"</sonar.coverage.exclusions>

--- a/commons-packet/commons-packet-service/pom.xml
+++ b/commons-packet/commons-packet-service/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.mosip.commons</groupId>
     <artifactId>commons-packet-service</artifactId>
-    <version>1.3.1-rc.1</version>
+    <version>1.3.1-SNAPSHOT</version>
     <name>commons-packet-service</name>
     <description>Mosip commons project </description>
     <url>https://github.com/mosip/commons</url>
@@ -29,16 +29,16 @@
         <!-- spring -->
         <swagger.version>2.9.2</swagger.version>
      
-        <kernel.core.version>1.3.1-rc.1</kernel.core.version>
+        <kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
         <kernel.biometrics.api.version>1.3.0</kernel.biometrics.api.version>
         <kernel.auth.adaptor.version>1.3.0</kernel.auth.adaptor.version>
-        <kernel-dataaccess-hibernate.version>1.3.1-rc.1</kernel-dataaccess-hibernate.version>
-        <kernel.logger.logback.version>1.3.1-rc.1</kernel.logger.logback.version>
-        <khazana.version>1.3.2-rc.1</khazana.version>
-        <kernel.bom.version>1.3.1-rc.1</kernel.bom.version>
+        <kernel-dataaccess-hibernate.version>1.3.1-SNAPSHOT</kernel-dataaccess-hibernate.version>
+        <kernel.logger.logback.version>1.3.1-SNAPSHOT</kernel.logger.logback.version>
+        <khazana.version>1.3.2-SNAPSHOT</khazana.version>
+        <kernel.bom.version>1.3.1-SNAPSHOT</kernel.bom.version>
         <sonar.coverage.exclusions>**/constant/**,**/config/**,**/httpfilter/**,**/cache/**,**/dto/**,**/entity/**,**/model/**,**/exception/**,**/repository/**,**/security/**,**/*Config.java,**/*BootApplication.java,**/*VertxApplication.java,**/cbeffutil/**,**/*Utils.java,**/*Validator.java,**/*Helper.java,**/verticle/**,**/VidWriter.java/**,**/masterdata/utils/**,**/spi/**,**/core/http/**,"**/LocationServiceImpl.java","**/RegistrationCenterMachineServiceImpl.java","**/RegistrationCenterServiceImpl.java","**/pridgenerator/**","**/idgenerator/prid","**/proxy/**","**/cryptosignature/**"</sonar.coverage.exclusions>
         <sonar.cpd.exclusions>**/dto/**,**/entity/**,**/config/**</sonar.cpd.exclusions>
-        <packet.manager.version>1.3.1-rc.1</packet.manager.version>
+        <packet.manager.version>1.3.1-SNAPSHOT</packet.manager.version>
         <jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
         <central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
 

--- a/commons-packet/pom.xml
+++ b/commons-packet/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.mosip.commons</groupId>
     <artifactId>commons-packet</artifactId>
-    <version>1.3.1-rc.1</version>
+    <version>1.3.1-SNAPSHOT</version>
     <name>common-packet</name>
     <description>Common packet manager for MOSIP</description>
     <url>https://github.com/mosip/packet-manager</url>

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=packetmanager
-CHART_VERSION=1.3.1-rc.1-develop
+CHART_VERSION=1.3.1-develop
 
 echo Create $NS namespace
 kubectl create ns $NS 

--- a/helm/packetmanager/Chart.yaml
+++ b/helm/packetmanager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: packetmanager
 description: A Helm chart for MOSIP Packetmanager module
 type: application
-version: 1.3.1-rc.1-develop
+version: 1.3.1-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/packetmanager/values.yaml
+++ b/helm/packetmanager/values.yaml
@@ -46,8 +46,8 @@ service:
   externalTrafficPolicy: Cluster
 image:
   registry: docker.io
-  repository: mosipid/commons-packet-service
-  tag: 1.3.1-rc.1
+  repository: mosipqa/commons-packet-service
+  tag: 1.3.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Convert rc versions to SNAPSHOT in pom.xml, update Chart.yaml and install.sh chart_version to 1.3.1-develop, and point values.yaml image repository to mosipqa with tag 1.3.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application and deployment versions for the 1.3.1 development snapshot.
  * Updated installation and Helm chart configuration to use the development release.
  * Switched the container image source and tag for development deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->