### PR TITLE
Fix sonar_analysis CI failure by adding sonar profile to child modules

### DIFF
--- a/commons-packet/commons-packet-manager/pom.xml
+++ b/commons-packet/commons-packet-manager/pom.xml
@@ -344,14 +344,6 @@
                             <groupId>org.sonarsource.scanner.maven</groupId>
                             <artifactId>sonar-maven-plugin</artifactId>
                             <version>${maven.sonar.plugin.version}</version>
-                            <executions>
-                                <execution>
-                                    <phase>verify</phase>
-                                    <goals>
-                                        <goal>sonar</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
                         </plugin>
                     </plugins>
                 </build>

--- a/commons-packet/commons-packet-manager/pom.xml
+++ b/commons-packet/commons-packet-manager/pom.xml
@@ -43,6 +43,7 @@
         <sonar.coverage.exclusions>**/constants/**,**/config/**,**/audit/**,**/util/**,**/dto/**,**/entity/**,**/model/**,**/exception/**,**/repository/**,**/security/**,**/*Config.java,**/*BootApplication.java,**/*VertxApplication.java,**/cbeffutil/**,**/*Utils.java,**/*Validator.java,**/*Helper.java,**/verticle/**,**/VidWriter.java/**,**/masterdata/utils/**,**/spi/**,**/core/http/**,"**/LocationServiceImpl.java","**/RegistrationCenterMachineServiceImpl.java","**/RegistrationCenterServiceImpl.java","**/pridgenerator/**","**/idgenerator/prid","**/proxy/**","**/cryptosignature/**"</sonar.coverage.exclusions>
         <sonar.cpd.exclusions>**/dto/**,**/entity/**,**/config/**</sonar.cpd.exclusions>
         <jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
+        <maven.sonar.plugin.version>3.7.0.1746</maven.sonar.plugin.version>
 
  </properties>
     <dependencyManagement>
@@ -325,4 +326,35 @@
                   <organizationUrl>https://github.com/mosip/commons</organizationUrl>
                 </developer>
         </developers>
+        <profiles>
+            <profile>
+                <id>sonar</id>
+                <properties>
+                    <sonar.sources>.</sonar.sources>
+                    <sonar.inclusions>src/main/java/**,src/main/resources/**</sonar.inclusions>
+                    <sonar.exclusions>${sonar.coverage.exclusions}</sonar.exclusions>
+                    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+                </properties>
+                <activation>
+                    <activeByDefault>false</activeByDefault>
+                </activation>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.sonarsource.scanner.maven</groupId>
+                            <artifactId>sonar-maven-plugin</artifactId>
+                            <version>${maven.sonar.plugin.version}</version>
+                            <executions>
+                                <execution>
+                                    <phase>verify</phase>
+                                    <goals>
+                                        <goal>sonar</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </build>
+            </profile>
+        </profiles>
 	</project>

--- a/commons-packet/commons-packet-service/pom.xml
+++ b/commons-packet/commons-packet-service/pom.xml
@@ -400,14 +400,6 @@
                         <groupId>org.sonarsource.scanner.maven</groupId>
                         <artifactId>sonar-maven-plugin</artifactId>
                         <version>${maven.sonar.plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sonar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/commons-packet/commons-packet-service/pom.xml
+++ b/commons-packet/commons-packet-service/pom.xml
@@ -41,6 +41,7 @@
         <packet.manager.version>1.3.1-SNAPSHOT</packet.manager.version>
         <jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
         <central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+        <maven.sonar.plugin.version>3.7.0.1746</maven.sonar.plugin.version>
 
  </properties>
  <dependencyManagement>
@@ -378,6 +379,35 @@
                             <outputDir>${project.build.directory}</outputDir>
                             <skip>false</skip>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>sonar</id>
+            <properties>
+                <sonar.sources>.</sonar.sources>
+                <sonar.inclusions>src/main/java/**,src/main/resources/**</sonar.inclusions>
+                <sonar.exclusions>${sonar.coverage.exclusions}</sonar.exclusions>
+                <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+            </properties>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonarsource.scanner.maven</groupId>
+                        <artifactId>sonar-maven-plugin</artifactId>
+                        <version>${maven.sonar.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sonar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/commons-packet/pom.xml
+++ b/commons-packet/pom.xml
@@ -258,14 +258,6 @@
                             <groupId>org.sonarsource.scanner.maven</groupId>
                             <artifactId>sonar-maven-plugin</artifactId>
                             <version>${maven.sonar.plugin.version}</version>
-                            <executions>
-                                <execution>
-                                    <phase>verify</phase>
-                                    <goals>
-                                        <goal>sonar</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
                         </plugin>
                     </plugins>
                 </build>


### PR DESCRIPTION
commons-packet-manager and commons-packet-service have no <parent> link to commons-packet, so they never inherited the sonar profile declaring sonar-maven-plugin. CI's 'mvn -Psonar verify sonar:sonar' therefore failed to resolve the sonar:sonar goal prefix for them with a cold Maven cache (No plugin found for prefix 'sonar'), masked previously by lucky GitHub Actions cache restores. Verified locally: reproduced the failure with a fresh local repo on the prior rc.1 commit too (pre-existing, unrelated to the QA version-bump), and confirmed this fix resolves it (build proceeds past the sonar goal resolution).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added optional static code analysis configuration for packet manager and service components.
  * Configured analysis scope, inclusion and exclusion rules, and server connectivity settings.
  * Sonar analysis no longer runs automatically during the standard verification process and can be enabled separately when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->